### PR TITLE
Update the first page of the CV and Add GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+# Basic workflow that:
+# --> lints the markdown in the README file
+# --> checks to ensure that files and directories exist
+name: build
+
+# Controls when the action will run.
+# Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs
+# that can run sequentially or in parallel
+jobs:
+  # The workflow contains a single job called "build"
+  build:
+    # The runner will run on the latest version of Ubuntu
+    runs-on: ubuntu-latest
+
+    # Define the steps run in the workflow
+    steps:
+      # Run the mdl linting tool, which references
+      # the .mdlrc file stored in the repo's root
+      # for further configuration details
+      - name: Check out code
+        uses: actions/checkout@master
+      - name: Run mdl
+        uses: actionshub/markdownlint@master

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # curriculum-vitae
 
 This repository contains the curriculum vitae (CV) of me, [Gregory M.
-Kapfhammer](http://www.cs.allegheny.edu/sites/gkapfham). This repository uses
+Kapfhammer](https://www.gregorykapfhammer.com/). This repository uses
 [gkapfham/research-bibliography](https://github.com/gkapfham/research-bibliography)
 as a Git submodule to create several pages of the document in an automated
 fashion. Parts of this CV are inspired by the example provided at

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ purposes. If you find this example useful, I would appreciate it if, in addition
 to starring the repository, you mention that you used my CV as a template when
 creating your document.
 
-### Development Environment
+## Development Environment
 
 The curriculum vitae is compiled on an Ubuntu 16.04 LTS workstation using
 `pdflatex` and `biber`. You may also compile the CV to a PDF file using a wide
@@ -22,7 +22,7 @@ variety of other tools, such as `latexmk`. If you are unable to compile the CV
 with your development tools and your execution environment, then please open a
 new issue and I will attempt to resolve your concerns.
 
-### Creating the Curriculum Vitae
+## Creating the Curriculum Vitae
 
 ```shell
 git clone https://github.com/gkapfham/curriculum-vitae.git

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -134,41 +134,73 @@
 \section{Education}
 
 % Removing forced punctuation from cvitem
+%
 \input{cvitem_modifications/cvitem_modified}
 
-\tldatecventry{2007}{Ph.D.\ in Computer Science}{\em{University of Pittsburgh}}{Adviser: Dr.\ Mary Lou Soffa}{}{Title:
-\em{A Comprehensive Framework for Testing Database-Centric Applications}}
+% PhD Dissertation
+%
+\tldatecventry{2007}{Ph.D.\ in Computer Science}{\em{University of
+Pittsburgh}}{Adviser: Dr.\ Mary Lou Soffa}{}{Title: \em{A Comprehensive
+Framework for Testing Database-Centric Applications}}
 
-\tldatecventry{2004}{M.S.\ in Computer Science}{\em{University of Pittsburgh}}{Adviser: Dr.\ Mary Lou Soffa}{}{Title:
-\em{A Family of Test Adequacy Criteria for Database-Centric Applications}}
+% MSc thesis
+%
+\tldatecventry{2004}{M.S.\ in Computer Science}{\em{University of
+Pittsburgh}}{Adviser: Dr.\ Mary Lou Soffa}{}{Title: \em{A Family of Test
+Adequacy Criteria for Database-Centric Applications}}
 
-\tldatecventry{1999}{B.S.\ in Computer Science}{\em{Allegheny College}}{Adviser: Dr.\ Robert D.\ Cupper}{}{Title: \em{A
-Complex Object Data Generator Specification Language to Facilitate \\ \hspace*{.35in} Automated Data Creation in
-Software Component Test Drivers}}
+% BSc thesis
+%
+\tldatecventry{1999}{B.S.\ in Computer Science}{\em{Allegheny College}}{Adviser:
+Dr.\ Robert D.\ Cupper}{}{Title: \em{A Complex Object Data Generator
+Specification Language to Facilitate \\ \hspace*{.35in} Automated Data Creation
+in Software Component Test Drivers}}
 
+% Summary of activities in current appointment
+%
 \vspace*{-.1in}
+%
 \section{Current Appointment}
 
-\tlcventry{2000}{0}{Associate Professor and Chair}{\em{Department of Computer Science, Allegheny College}}{}{Chair
-(2013-2019), Associate Professor (2009-Present), Assistant Professor (2007-2009), Instructor (2000-2007)}
-{\begin{itemize}
-    \renewcommand\labelitemi{\Large\textbullet}
-  \item Articulated a vision and furnished daily leadership that resulted in increases in majors, minors, and
-    course enrollments, improved student engagement, and enhanced teaching and research facilities.
-  \item Developed the Applied Computer Science major that imparts the knowledge and skills needed for success in the
-    fields of software development, software project management, and entrepreneurship.
-  \item Enhanced and delivered courses in the areas of introductory computer science, data structures,
-    algorithms, data management, and operating systems (Computer Science 111, 112, 380, and 440).
-  \item Designed and delivered new courses in the areas of software development, distributed systems, and computer
-    science internships (Computer Science 280, 441, 500/501/510, 511, and 512).
-  \item Improved and taught a methods and topics in computing research course (Computer Science
-    580).
-  \item Supervised award-winning undergraduate thesis research (Computer Science 600 and 610).
-  \item Served as both an academic and research adviser for graduate and undergraduate students.
-  \item Represented the faculty as a member of the College's Academic Standards and Awards Committee.
-  \item Served as the Natural Science Division's representative on the self-study committee assessing the
-    objectives and effectiveness of the College's first-year/sophomore writing and speaking program.
-  \end{itemize}}
+\tlcventry{2000}{0}{Associate Professor}{\em{Department of Computer Science,
+  Allegheny College}}{}{Chair (2013-2019), Associate Professor (2009-Present),
+  Assistant Professor (2007-2009), Instructor (2000-2007)} {
+  %
+  \begin{itemize} \renewcommand\labelitemi{\Large\textbullet}
+    %
+  \item Articulated a vision and furnished daily leadership that resulted in
+    increases in majors, minors, and course enrollments, improved student
+    engagement, and enhanced teaching and research facilities.
+    %
+  \item Redesigned the Computer Science major so that it imparts the technical
+    knowledge and skills needed for success in the fields of software
+    engineering, applied computer science, and technology entrepreneurship.
+    %
+  \item Taught Computer Science courses in technical areas including data
+    structures and software engineering.
+    %
+  % \item Improved and taught a methods and topics in computing research course
+    % (Computer Science 580).
+    %
+  % \item Supervised award-winning undergraduate thesis research (Computer Science
+    % 600 and 610).
+    %
+  \item Directed the engineering of open-source software tools regularly used in
+    production environments.
+    %
+  \item Served as both an academic and research adviser for both graduate and
+    undergraduate students.
+    %
+  \item Represented the faculty as a member of the College's Academic Standards
+    and Awards Committee.
+    %
+  \item Served as the Natural Science Division's representative on the
+    self-study committee tasked with assessing the objectives and effectiveness
+    of the College's first-year/sophomore writing and speaking program.
+    %
+\end{itemize}
+%
+  }
 
 \vspace*{-.1in}
 \section{Prior Appointments}

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -168,39 +168,33 @@ in Software Component Test Drivers}}
   %
   \begin{itemize} \renewcommand\labelitemi{\Large\textbullet}
     %
-  \item Articulated a vision and furnished daily leadership that resulted in
-    increases in majors, minors, and course enrollments, improved student
-    engagement, and enhanced teaching and research facilities.
-    %
-  \item Redesigned the Computer Science major so that it imparts the technical
-    knowledge and skills needed for success in the fields of software
-    engineering, applied computer science, and technology entrepreneurship.
-    %
-  \item Taught Computer Science courses in technical areas including data
-    structures and software engineering.
-    %
-  % \item Improved and taught a methods and topics in computing research course
-    % (Computer Science 580).
-    %
-  % \item Supervised award-winning undergraduate thesis research (Computer Science
-    % 600 and 610).
-    %
-  \item Directed the engineering of open-source software tools regularly used in
-    production environments.
-    %
-  \item Served as both an academic and research adviser for both graduate and
-    undergraduate students.
-    %
-  \item Represented the faculty as a member of the College's Academic Standards
-    and Awards Committee.
-    %
-  \item Served as the Natural Science Division's representative on the
-    self-study committee tasked with assessing the objectives and effectiveness
-    of the College's first-year/sophomore writing and speaking program.
-    %
-\end{itemize}
-%
-  }
+    \item Articulated a vision and furnished daily leadership that resulted in
+      increases in majors, minors, and course enrollments, improved student
+      engagement, and enhanced teaching and research facilities.
+      %
+    \item Redesigned the Computer Science major so that it imparts the technical
+      knowledge and skills needed for success in the fields of software
+      engineering, applied computer science, and technology entrepreneurship.
+      %
+    \item Taught Computer Science courses in technical areas including data
+      structures and software engineering.
+      %
+    \item Directed the engineering of open-source software tools regularly used in
+      production environments.
+      %
+    \item Served as both an academic and research adviser for both graduate and
+      undergraduate students.
+      %
+    \item Represented the faculty as a member of the College's Academic Standards
+      and Awards Committee.
+      %
+    \item Served as the Natural Science Division's representative on the
+      self-study committee tasked with assessing the objectives and effectiveness
+      of the College's first-year/sophomore writing and speaking program.
+      %
+  \end{itemize}
+  %
+}
 
 \vspace*{-.1in}
 \section{Prior Appointments}


### PR DESCRIPTION
This PR revises the first page of the CV and then adds GitHub Actions support.

- Revised all content on the first page of curriculum_vitae_kapfhammer.
- Remove commented-out content in the curriculum_vitae_kapfhammer.
- Fix mistake in README where sections go too deep too quickly.
- Fix the incorrect link to my web site in the README.
- Add starting version of the build.yml file to trigger GitHub Actions.
