### PR TITLE
feat/add students software

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,14 @@ creating your document.
 
 ## Development Environment
 
-The curriculum vitae is compiled on an Ubuntu 16.04 LTS workstation using
-`pdflatex` and `biber`. You may also compile the CV to a PDF file using a wide
-variety of other tools, such as `latexmk`. If you are unable to compile the CV
-with your development tools and your execution environment, then please open a
-new issue and I will attempt to resolve your concerns.
+The curriculum vitae was originally compiled on an Ubuntu 16.04 LTS workstation
+using `pdflatex` and `biber` from an old version of TeXLive. The curriculum
+vitae is now compiled on an Arch Linux workstation using `latexmk` from the
+TeXLive 2021 distribution. You should be able to compile the CV to a PDF file
+using a wide variety of tools and operating systems and versions of TeXLive. If
+you are unable to compile the CV with your development tools and your execution
+environment, then please open a new issue and I will attempt to resolve your
+concerns.
 
 ## Creating the Curriculum Vitae
 
@@ -32,7 +35,8 @@ For, clone the repository to your local computer:
 git clone https://github.com/gkapfham/curriculum-vitae.git
 ```
 
-Now, change into the directory that contains the repository's files:
+Now, change into the directory that contains the repository's files and follow
+all of the following steps the first time that you compile the CV:
 
 ```shell
 cd curriculum-vitae
@@ -46,8 +50,8 @@ pdflatex curriculum_vitae_kapfhammer.tex
 pdflatex curriculum_vitae_kapfhammer.tex
 ```
 
-Before you compile the CV, make sure that you have the bibliography in a Git
-submodule:
+Remember, before you compile the CV, make sure that you have the bibliography in
+a Git submodule:
 
 ```shell
 cd bibliography
@@ -56,7 +60,7 @@ git submodule update
 cd ../
 ```
 
-At this point, you can compile the CV using the following commands:
+As a reminder, you can compile the CV using the following commands:
 
 ```shell
 pdflatex curriculum-vitae-kapfhammer.tex
@@ -65,7 +69,8 @@ pdflatex curriculum_vitae_kapfhammer.tex
 pdflatex curriculum_vitae_kapfhammer.tex
 ```
 
-Alternatively, you can compile the CV using a single command:
+Alternatively, once you have access to the `bibliography` submodule you can
+compile the CV using a single command:
 
 ```shell
 latexmk -pdf -pvc curriculum_vitae_kapfhammer.tex

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -788,7 +788,7 @@ In addition to yearly senior thesis advising as part of CMPSC 600/601, I co-supe
 
 \tlcventry{2007}{2009}{Ankita Mahajan}{}{}{}{Master of Computer Science, Delhi University, Primary Supervision by Vidya Kulkarni}
 
-\vspace*{-.1in}
+\vspace*{-.4in}
 %
 \section{Institutional Service}
 

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -847,9 +847,11 @@ materials, interviewed final candidates.}
 \vspace*{-.175in}
 \section{Outreach Activities}
 
-\tlcventry{2018}{2019}{Allegheny College}{}{}{}{Participated in panels for prospective students in events organized by the Office of Admissions}
+\tlcventry{2018}{2019}{Allegheny College}{}{}{}{Participated in panels for
+prospective students in events organized by the Office of Admissions}
 
-\tldatecventry{2018}{Allegheny College}{}{}{}{Introduced high school guidance counselors to computer science in event by Office of Admissions}
+\tldatecventry{2018}{Allegheny College}{}{}{}{Introduced high school guidance
+counselors to computer science in event by Office of Admissions}
 
 \tldatecventry{2011}{Cochranton Elementary School}{}{}{}{Developed, used,
 and evaluated computer-based instructional methods for teaching geometry.}

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -770,6 +770,10 @@ In addition to yearly senior thesis advising as part of CMPSC 600/601, I co-supe
 %
 \vspace*{.1in}
 
+\tlcventry{2019}{2022}{Owain Parry}{}{}{}{Doctor of Philosophy (expected), University of Sheffield, Primary Supervision by Phil McMinn}
+
+\tlcventry{2017}{2021}{Ibrahim Althomali}{}{}{}{Doctor of Philosophy (expected), University of Sheffield, Primary Supervision by Phil McMinn}
+
 \tlcventry{2016}{2020}{Abdullah Alsharif}{}{}{}{Doctor of Philosophy, University of Sheffield, Primary Supervision by Phil McMinn}
 
 \tlcventry{2015}{2019}{David Paterson}{}{}{}{Doctor of Philosophy, University of Sheffield, Primary Supervision by Phil McMinn}
@@ -796,7 +800,7 @@ In addition to yearly senior thesis advising as part of CMPSC 600/601, I co-supe
 
 \tlcventry{2007}{2009}{Ankita Mahajan}{}{}{}{Master of Computer Science, Delhi University, Primary Supervision by Vidya Kulkarni}
 
-\vspace*{-.4in}
+\vspace*{-.1in}
 %
 \section{Institutional Service}
 
@@ -836,29 +840,27 @@ talks, and chaired all of the sessions.}
 Applied Computing Major}{}{}{}{Prepared outlines, conducted background research,
 collected and analyzed data, and wrote report.}
 
-\tlcventry{2001}{0}{Member of the Department of Computer Science's Faculty
+\tlcventry{2001}{0}{Standing member of the Department of Computer Science's Faculty
 Search Committee}{}{}{}{Prepared position advertisements, evaluated applicants'
 materials, interviewed final candidates.}
 
-% TODO: Consider adding these back? Are these new examples to also share? What about SEED?
+\vspace*{-.175in}
+\section{Outreach Activities}
 
-% \vspace*{-.175in}
-% \section{Outreach Activities}
+\tldatecventry{2011}{Cochranton Elementary School}{}{}{}{Developed, used,
+and evaluated computer-based instructional methods for teaching geometry.}
 
-% \tldatecventry{2011}{Cochranton Elementary School}{}{}{}{Developed, employed,
-% and evaluated computer-based instructional methods for teaching geometry.}
+\tldatecventry{2009}{Merrimack College}{}{}{}{Delivered lectures and hosted
+events introducing the theory and practice of software engineering.}
 
-% \tldatecventry{2009}{Merrimack College}{}{}{}{Delivered lectures and hosted
-% events introducing the theory and practice of software engineering.}
-
-% \tldatecventry{2004}{Allegheny College}{}{}{}{Introduced the fundamentals of
-% computer science to attendees of an off-campus faculty conference.}
+\tldatecventry{2004}{Allegheny College}{}{}{}{Introduced the fundamentals of
+computer science to attendees of an off-campus faculty conference.}
 
 \vspace*{-.175in}
 %
 \section{Professional Distinctions}
 
-\tldatecventry{2019}{Best Paper at the 12th International International
+\tldatecventry{2019}{Distinguished Paper at the 12th International International
 Conference on Software Testing, Verification and Validation}{}{}{}{``Automatic
 visual verification of layout failures in responsively designed web pages,''
 co-authored with Ibrahim Althomali and Phil McMinn. \vspace*{.1in}}
@@ -868,18 +870,16 @@ Search-Based Software Testing}{}{}{}{``Hitchhikers need free vehicles!~Shared
 repositories for statistical analysis in {SBST},'' co-authored with Phil McMinn.
 \vspace*{.1in}}
 
-% NOTE: Commented out two of the items due to current space constraints
-
 \tldatecventry{2011}{Recipient of Allegheny College's Thoburn Award for Excellence in Teaching}{}{}{}
 {Award citations include the following observations: \vspace*{.025in}
   \begin{itemize}
     \renewcommand\labelitemi{\Large\textbullet}
-    % \item ``rigorous yet caring instruction''
+    \item ``rigorous yet caring instruction''
     \item ``demonstrates love for the subject of computer science''
     \item ``exhibits a teaching style that is exuberant, exciting, and passionate''
     \item ``innovative research is an integral part of his students’ learning experience''
     \item ``assignments are challenging and have a meaningful relationship to the real world''
-    % \item ``excels at bringing advanced topics down to a level that makes them easy to comprehend''
+    \item ``excels at bringing advanced topics down to a level that makes them easy to comprehend''
     \item ``goes above and beyond for those in his classes; he has his students’ best interests in mind''
   \end{itemize}}
 

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -498,6 +498,8 @@ the influence that technology has on society.}
 %
 \printbibliography[filter=volumesedited,title={Volumes Edited}]
 
+% SOFTWARE
+%
 \vspace*{-.4in}
 %
 \section{Software}
@@ -518,10 +520,14 @@ the influence that technology has on society.}
 
 \tlcventry{2018}{2021}{TaDA: Automated order-of-growth analysis for Python functions}{}{}{}{https://github.com/Tada-Project/tada}
 
+% PROFESSIONAL SERVICE
+%
 \vspace*{-.15in}
 %
 \section{Professional Service}
 
+% PROFESSIONAL SERVICE -- Conferences and Workshops
+%
 \subsection{Conferences and Workshops}
 
 \tlcventry{2020}{2021}{International Conference on Automated Software
@@ -686,6 +692,8 @@ Engineering}{}{}{}{Session Chair (One time)}
 
 \tldatecventry{2003}{International Conference on Distributed Computing Systems}{}{}{}{Reviewer (One time)}
 
+% PROFESSIONAL SERVICE -- Transactions and Journals
+%
 \subsection{Transactions and Journals}
 
 \tlcventry{2019}{2021}{Journal of Software: Evolution and Process}{}{}{}{Associate Editor}

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -770,14 +770,6 @@ Engineering}{}{}{}{Session Chair (One time)}
 %   type   = {MSc thesis},
 % }
 
-% @mastersthesis{Bansal2010,
-%   author = {Ritu Bansal and Nancy Gupta},
-%   title  = {Coverage monitor for JUnit testing of Java programs with XQuery},
-%   school = {Department of Computer Science, University of Delhi},
-%   year   = {2010},
-%   type   = {MSc thesis},
-% }
-
 \vspace*{-.1in}
 
 \section{Research Supervision}
@@ -785,6 +777,12 @@ Engineering}{}{}{}{Session Chair (One time)}
 In addition to yearly senior thesis advising as part of CMPSC 600/601, I co-supervise graduate-level researchers.
 %
 \vspace*{.1in}
+
+\tlcventry{2009}{2011}{Akansha Aggarwal}{}{}{}{Master of Computer Science, Delhi University, Primary Supervision by Vidya Kulkarni}
+
+\tlcventry{2009}{2011}{Nidhi Aggarwal}{}{}{}{Master of Computer Science, Delhi University, Primary Supervision by Vidya Kulkarni}
+
+\tlcventry{2009}{2011}{Aarti Sethiya}{}{}{}{Master of Computer Science, Delhi University, Primary Supervision by Vidya Kulkarni}
 
 \tlcventry{2008}{2010}{Ritu Bansal}{}{}{}{Master of Computer Science, Delhi University, Primary Supervision by Vidya Kulkarni}
 

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -778,14 +778,6 @@ Engineering}{}{}{}{Session Chair (One time)}
 %   type   = {MSc thesis},
 % }
 
-% @mastersthesis{Agrawal2009,
-%   author = {Arpan Agrawal and Ankita Mahajan},
-%   title  = {An XML-aware regression testing framework},
-%   school = {Department of Computer Science, University of Delhi},
-%   year   = {2009},
-%   type   = {MSc thesis},
-% }
-
 \vspace*{-.1in}
 
 \section{Research Supervision}
@@ -794,9 +786,13 @@ In addition to yearly senior thesis advising as part of CMPSC 600/601, I co-supe
 %
 \vspace*{.1in}
 
-\tlcventry{2008}{2012}{Kristen R. Walcott}{}{}{}{Doctor of Philosophy, University of Virginia, Primary Supervision by Mary Lou Soffa}
+\tlcventry{2008}{2010}{Ritu Bansal}{}{}{}{Master of Computer Science, Delhi University, Primary Supervision by Vidya Kulkarni}
+
+\tlcventry{2008}{2010}{Nancy Gupta}{}{}{}{Master of Computer Science, Delhi University, Primary Supervision by Vidya Kulkarni}
 
 \tlcventry{2008}{2012}{Ren\'{e} Just}{}{}{}{Doctor of Philosophy, University of Ulm, Primary Supervision by Franz Schweiggert}
+
+\tlcventry{2008}{2012}{Kristen R. Walcott}{}{}{}{Doctor of Philosophy, University of Virginia, Primary Supervision by Mary Lou Soffa}
 
 \tlcventry{2007}{2009}{Arpan Agrawal}{}{}{}{Master of Computer Science, Delhi University, Primary Supervision by Vidya Kulkarni}
 

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -850,7 +850,10 @@ collected and analyzed data, and wrote report.}
 Search Committee}{}{}{}{Prepared position advertisements, evaluated applicants'
 materials, interviewed final candidates.}
 
-\vspace*{-.175in}
+% OUTREACH ACTIVITIES
+%
+\vspace*{-.1in}
+%
 \section{Outreach Activities}
 
 \tlcventry{2018}{2019}{Allegheny College}{}{}{}{Participated in panels for
@@ -868,7 +871,8 @@ events introducing the theory and practice of software engineering.}
 \tldatecventry{2004}{Allegheny College}{}{}{}{Introduced the fundamentals of
 computer science to attendees of an off-campus faculty conference.}
 
-\newpage
+\tlcventry{2000}{0}{Allegheny College}{}{}{}{Introduced prospective students
+to computer science at events organized by the Office of Admissions.}
 
 % PROFESSIONAL DISTINCTIONS
 %

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -848,10 +848,10 @@ materials, interviewed final candidates.}
 \section{Outreach Activities}
 
 \tlcventry{2018}{2019}{Allegheny College}{}{}{}{Participated in panels for
-prospective students in events organized by the Office of Admissions}
+prospective students in events organized by the Office of Admissions.}
 
 \tldatecventry{2018}{Allegheny College}{}{}{}{Introduced high school guidance
-counselors to computer science in event by Office of Admissions}
+counselors to computer science in event by Office of Admissions.}
 
 \tldatecventry{2011}{Cochranton Elementary School}{}{}{}{Developed, used,
 and evaluated computer-based instructional methods for teaching geometry.}

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -439,7 +439,7 @@ the influence that technology has on society.}
   %
 }
 
-% Removing forced punctuation from cvitem
+% Remove forced punctuation from cvitem
 %
 \input{cvitem_modifications/cvitem_modified}
 
@@ -470,7 +470,7 @@ the influence that technology has on society.}
 \DeclareFieldFormat[inproceedings]{title}{\mkbibquote{#1\addcomma}}
 \DeclareFieldFormat[incollection]{title}{\mkbibquote{#1\addcomma}}
 
-% \vspace*{-.1in}
+% Print the bibliography
 %
 \printbibliography[filter=papers,title={Publications}]
 

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -504,15 +504,15 @@ the influence that technology has on society.}
 %
 \section{Software}
 
-\tlcventry{2019}{2021}{CommitCanvas: Automated prediction of commit labels for version control messages}{}{}{}{https://github.com/CommittedTeam/CommitCanvas}
+\tlcventry{2019}{0}{CommitCanvas: Automated prediction of commit labels for version control messages}{}{}{}{https://github.com/CommittedTeam/CommitCanvas}
 
-\tlcventry{2019}{2021}{Dockagator: Docker image and infrastructure to run GatorGrader and GatorGradle}{}{}{}{https://github.com/GatorEducator/dockagator}
+\tlcventry{2019}{0}{Dockagator: Docker container and infrastructure to run GatorGrader and GatorGradle}{}{}{}{https://github.com/GatorEducator/dockagator}
 
-\tlcventry{2018}{2021}{TaDA: Automated order-of-growth analysis for Python functions}{}{}{}{https://github.com/Tada-Project/tada}
+\tlcventry{2018}{0}{TaDa: Automated order-of-growth analysis for Python functions}{}{}{}{https://github.com/Tada-Project/tada}
 
-\tlcventry{2018}{2021}{GatorGradle: Gradle plugin to support the use of GatorGrader}{}{}{}{https://github.com/GatorEducator/gatorgradle}
+\tlcventry{2018}{0}{GatorGradle: Gradle plugin to support the use of GatorGrader}{}{}{}{https://github.com/GatorEducator/gatorgradle}
 
-\tlcventry{2017}{2021}{GatorGrader: Automated assessment for source code and technical writing}{}{}{}{https://github.com/GatorEducator/gatorgrader}
+\tlcventry{2017}{0}{GatorGrader: Automated assessment for source code and technical writing}{}{}{}{https://github.com/GatorEducator/gatorgrader}
 
 \tlcventry{2016}{2020}{AVM{\em f}: Extensible framework for the search-based alternating variable method}{}{}{}{https://github.com/AVMf/avmf}
 

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -425,19 +425,17 @@ the influence that technology has on society.}
 
 {\small
   %
-  I am an associate editor for the Journal of Software: Evolution and Process,
-  an academic editor for the PeerJ Computer Science journal, a program
+  I am an associate editor for the {\em Journal of Software: Evolution and
+  Process}, an academic editor for {\em PeerJ Computer Science}, a program
   committee member for conferences like the International Conference on
   Software Testing, Verification and Validation and the International
   Conference on Automated Software Engineering, and a reviewer for journals
-  such as Transactions on Software Engineering and Information and Software
-  Technology. Along with contributing to open-source software, I collaborate
-  with researchers and engineers at leading academic institutions, government
-  agencies, and \mbox{technology companies}. My research is funded by grants
-  from the Office of the Provost at Allegheny College, the Mozilla Foundation,
-  and Facebook Research.
-  %
-  % My research is funded by the Mozilla Foundation and Facebook Research.
+  such as {\em Transactions on Software Engineering} and {\em Information and
+  Software Technology}. Along with contributing to open-source software, I
+  collaborate with researchers and engineers at leading academic institutions,
+  government agencies, and \mbox{technology companies}. My research is funded
+  by grants from the Office of the Provost at Allegheny College, the Mozilla
+  Foundation, and Facebook Research.
   %
 }
 

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -744,7 +744,9 @@ Engineering}{}{}{}{Session Chair (One time)}
 
 \tldatecventry{2002}{IEE Proceedings --- Software}{}{}{}{Reviewer (One time)}
 
-\subsection{Other Services}
+% PROFESSIONAL SERVICE -- Other Service
+%
+\subsection{Other Service}
 
 \tldatecventry{2016}{Natural Sciences and Engineering Research Council of Canada}{}{}{}{Discovery Grants Reviewer (One time)}
 

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -135,7 +135,7 @@
 \name{\textrm{Gregory}}{\\\mbox{\textrm{M.\ Kapfhammer}}}
 \title{\textrm{\huge{Associate Professor of Computer Science}}\vspace*{-.3in}}
 \address{Department of Computer Science\\Allegheny College\\}{}{}
-\phone[mobile]{+1 814-332-2880}
+\homepage{www.gregorykapfhammer.com}
 \email{gkapfham@allegheny.edu}
 
 % Define the fonts for sections and subsections

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -502,6 +502,16 @@ the influence that technology has on society.}
 
 \vspace*{-.4in}
 %
+\section{Software}
+
+\tlcventry{2016}{2021}{AVM{\em f}: Extensible framework for the search-based alternating variable method}{}{}{}{https://github.com/AVMf/avmf}
+
+\tlcventry{2019}{2021}{Dockagator: Docker image and infrastructure to run GatorGrader and GatorGradle}{}{}{}{https://github.com/GatorEducator/dockagator}
+
+\tlcventry{2017}{2021}{GatorGrader: Automated assessment for source code and technical writing}{}{}{}{https://github.com/GatorEducator/gatorgrader}
+
+\vspace*{-.1in}
+%
 \section{Professional Service}
 
 \subsection{Conferences and Workshops}

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -772,35 +772,35 @@ In addition to yearly senior thesis advising as part of CMPSC 600/601, I co-supe
 %
 \vspace*{.1in}
 
-\tlcventry{2019}{2022}{Owain Parry}{}{}{}{Doctor of Philosophy (expected), University of Sheffield, Primary Supervision by Phil McMinn}
+\tlcventry{2019}{2022}{Owain Parry}{}{}{}{Doctor of Philosophy (expected), University of Sheffield, Primary supervision by Phil McMinn}
 
-\tlcventry{2017}{2021}{Ibrahim Althomali}{}{}{}{Doctor of Philosophy (expected), University of Sheffield, Primary Supervision by Phil McMinn}
+\tlcventry{2017}{2021}{Ibrahim Althomali}{}{}{}{Doctor of Philosophy (expected), University of Sheffield, Primary supervision by Phil McMinn}
 
-\tlcventry{2016}{2020}{Abdullah Alsharif}{}{}{}{Doctor of Philosophy, University of Sheffield, Primary Supervision by Phil McMinn}
+\tlcventry{2016}{2020}{Abdullah Alsharif}{}{}{}{Doctor of Philosophy, University of Sheffield, Primary supervision by Phil McMinn}
 
-\tlcventry{2015}{2019}{David Paterson}{}{}{}{Doctor of Philosophy, University of Sheffield, Primary Supervision by Phil McMinn}
+\tlcventry{2015}{2019}{David Paterson}{}{}{}{Doctor of Philosophy, University of Sheffield, Primary supervision by Phil McMinn}
 
-\tlcventry{2014}{2018}{Thomas Walsh}{}{}{}{Doctor of Philosophy, University of Sheffield, Primary Supervision by Phil McMinn}
+\tlcventry{2014}{2018}{Thomas Walsh}{}{}{}{Doctor of Philosophy, University of Sheffield, Primary supervision by Phil McMinn}
 
-\tlcventry{2011}{2015}{Christopher Wright}{}{}{}{Doctor of Philosophy, University of Sheffield, Primary Supervision by Phil McMinn}
+\tlcventry{2011}{2015}{Christopher Wright}{}{}{}{Doctor of Philosophy, University of Sheffield, Primary supervision by Phil McMinn}
 
-\tlcventry{2009}{2011}{Akansha Aggarwal}{}{}{}{Master of Computer Science, Delhi University, Primary Supervision by Vidya Kulkarni}
+\tlcventry{2009}{2011}{Akansha Aggarwal}{}{}{}{Master of Computer Science, Delhi University, Primary supervision by Vidya Kulkarni}
 
-\tlcventry{2009}{2011}{Nidhi Aggarwal}{}{}{}{Master of Computer Science, Delhi University, Primary Supervision by Vidya Kulkarni}
+\tlcventry{2009}{2011}{Nidhi Aggarwal}{}{}{}{Master of Computer Science, Delhi University, Primary supervision by Vidya Kulkarni}
 
-\tlcventry{2009}{2011}{Aarti Sethiya}{}{}{}{Master of Computer Science, Delhi University, Primary Supervision by Vidya Kulkarni}
+\tlcventry{2009}{2011}{Aarti Sethiya}{}{}{}{Master of Computer Science, Delhi University, Primary supervision by Vidya Kulkarni}
 
-\tlcventry{2008}{2010}{Ritu Bansal}{}{}{}{Master of Computer Science, Delhi University, Primary Supervision by Vidya Kulkarni}
+\tlcventry{2008}{2010}{Ritu Bansal}{}{}{}{Master of Computer Science, Delhi University, Primary supervision by Vidya Kulkarni}
 
-\tlcventry{2008}{2010}{Nancy Gupta}{}{}{}{Master of Computer Science, Delhi University, Primary Supervision by Vidya Kulkarni}
+\tlcventry{2008}{2010}{Nancy Gupta}{}{}{}{Master of Computer Science, Delhi University, Primary supervision by Vidya Kulkarni}
 
-\tlcventry{2008}{2012}{Ren\'{e} Just}{}{}{}{Doctor of Philosophy, University of Ulm, Primary Supervision by Franz Schweiggert}
+\tlcventry{2008}{2012}{Ren\'{e} Just}{}{}{}{Doctor of Philosophy, University of Ulm, Primary supervision by Franz Schweiggert}
 
-\tlcventry{2008}{2012}{Kristen R. Walcott}{}{}{}{Doctor of Philosophy, University of Virginia, Primary Supervision by Mary Lou Soffa}
+\tlcventry{2008}{2012}{Kristen R. Walcott}{}{}{}{Doctor of Philosophy, University of Virginia, Primary supervision by Mary Lou Soffa}
 
-\tlcventry{2007}{2009}{Arpan Agrawal}{}{}{}{Master of Computer Science, Delhi University, Primary Supervision by Vidya Kulkarni}
+\tlcventry{2007}{2009}{Arpan Agrawal}{}{}{}{Master of Computer Science, Delhi University, Primary supervision by Vidya Kulkarni}
 
-\tlcventry{2007}{2009}{Ankita Mahajan}{}{}{}{Master of Computer Science, Delhi University, Primary Supervision by Vidya Kulkarni}
+\tlcventry{2007}{2009}{Ankita Mahajan}{}{}{}{Master of Computer Science, Delhi University, Primary supervision by Vidya Kulkarni}
 
 \vspace*{-.1in}
 %
@@ -860,7 +860,7 @@ materials, interviewed final candidates.}
 prospective students in events organized by the Office of Admissions.}
 
 \tldatecventry{2018}{Allegheny College}{}{}{}{Introduced high school guidance
-counselors to computer science in event by Office of Admissions.}
+counselors to computer science in event for the Office of Admissions.}
 
 \tldatecventry{2011}{Cochranton Elementary School}{}{}{}{Created, used,
 and evaluated computer-based instructional methods for teaching geometry.}

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -506,6 +506,8 @@ the influence that technology has on society.}
 
 \tlcventry{2016}{2020}{AVM{\em f}: Extensible framework for the search-based alternating variable method}{}{}{}{https://github.com/AVMf/avmf}
 
+\tlcventry{2019}{2021}{CommitCanvas: Automated prediction of commit labels for version control messages}{}{}{}{https://github.com/CommittedTeam/CommitCanvas}
+
 \tlcventry{2019}{2021}{Dockagator: Docker image and infrastructure to run GatorGrader and GatorGradle}{}{}{}{https://github.com/GatorEducator/dockagator}
 
 \tlcventry{2017}{2021}{GatorGrader: Automated assessment for source code and technical writing}{}{}{}{https://github.com/GatorEducator/gatorgrader}

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -762,14 +762,6 @@ Engineering}{}{}{}{Session Chair (One time)}
 
 \tlcventry{2005}{2006}{Prentice Hall Books}{}{}{}{Reviewer (Two times)}
 
-% @mastersthesis{Sethiya2011,
-%   author = {Aarti Sethiya and Akansha Aggarwal and Nidhi Aggarwal},
-%   title  = {A multi-objective regression testing framework},
-%   school = {Department of Computer Science, University of Delhi},
-%   year   = {2011},
-%   type   = {MSc thesis},
-% }
-
 \vspace*{-.1in}
 
 \section{Research Supervision}

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -806,6 +806,10 @@ In addition to yearly senior thesis advising as part of CMPSC 600/601, I co-supe
 %
 \section{Institutional Service}
 
+\tlcventry{2018}{2020}{Faculty Member of the Academic Standards and Awards
+Committee}{}{}{}{Evaluated the academic records of probationary students and
+voted on individual cases and appeals.}
+
 \tlcventry{2015}{2017}{Representative for the Natural Science
 Division}{}{}{}{Served on the committee reviewing the College's
 first-year/sophomore writing and speaking program.}
@@ -826,7 +830,7 @@ brainstorming activities and helped with a final report.}
 Subcommittee}{}{}{}{Examined teaching and research materials, interviewed
 faculty and staff, and wrote a final report.}
 
-\tlcventry{2007}{2020}{Faculty Member of the Academic Standards and Awards
+\tlcventry{2007}{2010}{Faculty Member of the Academic Standards and Awards
 Committee}{}{}{}{Evaluated the academic records of probationary students and
 voted on individual cases and appeals.}
 
@@ -855,7 +859,7 @@ prospective students in events organized by the Office of Admissions.}
 \tldatecventry{2018}{Allegheny College}{}{}{}{Introduced high school guidance
 counselors to computer science in event by Office of Admissions.}
 
-\tldatecventry{2011}{Cochranton Elementary School}{}{}{}{Developed, used,
+\tldatecventry{2011}{Cochranton Elementary School}{}{}{}{Created, used,
 and evaluated computer-based instructional methods for teaching geometry.}
 
 \tldatecventry{2009}{Merrimack College}{}{}{}{Delivered lectures and hosted
@@ -864,9 +868,11 @@ events introducing the theory and practice of software engineering.}
 \tldatecventry{2004}{Allegheny College}{}{}{}{Introduced the fundamentals of
 computer science to attendees of an off-campus faculty conference.}
 
-\vspace*{-.175in}
+\newpage
+
+% \vspace*{-.175in}
 %
-\section{Professional Distinctions}
+\section{Distinctions}
 
 \tldatecventry{2019}{Distinguished Paper at the 12th International International
 Conference on Software Testing, Verification and Validation}{}{}{}{``Automatic

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -847,6 +847,10 @@ materials, interviewed final candidates.}
 \vspace*{-.175in}
 \section{Outreach Activities}
 
+\tlcventry{2018}{2019}{Allegheny College}{}{}{}{Participated in panels for prospective students in events organized by the Office of Admissions}
+
+\tldatecventry{2018}{Allegheny College}{}{}{}{Introduced high school guidance counselors to computer science in event by Office of Admissions}
+
 \tldatecventry{2011}{Cochranton Elementary School}{}{}{}{Developed, used,
 and evaluated computer-based instructional methods for teaching geometry.}
 

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -768,9 +768,9 @@ Engineering}{}{}{}{Session Chair (One time)}
 %
 \section{Research Supervision}
 
-In addition to yearly senior thesis advising as part of CMPSC 600/601, I co-supervise graduate-level researchers.
+In addition to undergraduate thesis advising as part of CMPSC 600/601, I co-supervise graduate-level researchers.
 %
-\vspace*{.1in}
+\vspace*{.15in}
 
 \tlcventry{2019}{2022}{Owain Parry}{}{}{}{Doctor of Philosophy (expected), University of Sheffield, Primary supervision by Phil McMinn}
 

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -870,9 +870,9 @@ computer science to attendees of an off-campus faculty conference.}
 
 \newpage
 
-% \vspace*{-.175in}
+% PROFESSIONAL DISTINCTIONS
 %
-\section{Distinctions}
+\section{Professional Distinctions}
 
 \tldatecventry{2019}{Distinguished Paper at the 12th International International
 Conference on Software Testing, Verification and Validation}{}{}{}{``Automatic

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -786,24 +786,24 @@ Engineering}{}{}{}{Session Chair (One time)}
 %   type   = {MSc thesis},
 % }
 
-% @phdthesis{Just2012,
-%   author = {Ren\'{e} Just},
-%   title  = {On effective and efficient mutation analysis for unit and integration testing},
-%   school = {Institute for Applied Information Processing, University of Ulm},
-%   year   = {2012},
-%   type   = {PhD thesis},
-%   keywords = {supervised}
-% }
+\vspace*{-.1in}
 
-% @phdthesis{Walcott2012,
-%   author = {Kristen R. Walcott-Justice},
-%   title  = {Testing in resource-constrained environments},
-%   school = {Department of Computer Science, University of Virginia},
-%   year   = {2012},
-%   type   = {PhD Thesis}
-% }
+\section{Research Supervision}
+
+In addition to yearly senior thesis advising as part of CMPSC 600/601, I co-supervise graduate-level researchers.
+%
+\vspace*{.1in}
+
+\tlcventry{2008}{2012}{Kristen R. Walcott}{}{}{}{Doctor of Philosophy, University of Virginia, Primary Supervision by Mary Lou Soffa}
+
+\tlcventry{2008}{2012}{Ren\'{e} Just}{}{}{}{Doctor of Philosophy, University of Ulm, Primary Supervision by Franz Schweiggert}
+
+\tlcventry{2007}{2009}{Arpan Agrawal}{}{}{}{Master of Computer Science, Delhi University, Primary Supervision by Vidya Kulkarni}
+
+\tlcventry{2007}{2009}{Ankita Mahajan}{}{}{}{Master of Computer Science, Delhi University, Primary Supervision by Vidya Kulkarni}
 
 \vspace*{-.1in}
+%
 \section{Institutional Service}
 
 \tlcventry{2015}{2017}{Representative for the Natural Science

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -504,23 +504,23 @@ the influence that technology has on society.}
 %
 \section{Software}
 
-\tlcventry{2016}{2020}{AVM{\em f}: Extensible framework for the search-based alternating variable method}{}{}{}{https://github.com/AVMf/avmf}
-
 \tlcventry{2019}{2021}{CommitCanvas: Automated prediction of commit labels for version control messages}{}{}{}{https://github.com/CommittedTeam/CommitCanvas}
 
 \tlcventry{2019}{2021}{Dockagator: Docker image and infrastructure to run GatorGrader and GatorGradle}{}{}{}{https://github.com/GatorEducator/dockagator}
 
-\tlcventry{2017}{2021}{GatorGrader: Automated assessment for source code and technical writing}{}{}{}{https://github.com/GatorEducator/gatorgrader}
+\tlcventry{2018}{2021}{TaDA: Automated order-of-growth analysis for Python functions}{}{}{}{https://github.com/Tada-Project/tada}
 
 \tlcventry{2018}{2021}{GatorGradle: Gradle plugin to support the use of GatorGrader}{}{}{}{https://github.com/GatorEducator/gatorgradle}
+
+\tlcventry{2017}{2021}{GatorGrader: Automated assessment for source code and technical writing}{}{}{}{https://github.com/GatorEducator/gatorgrader}
+
+\tlcventry{2016}{2020}{AVM{\em f}: Extensible framework for the search-based alternating variable method}{}{}{}{https://github.com/AVMf/avmf}
 
 \tlcventry{2016}{2020}{Kanonizo: Improving fault detection with automated prioritization of JUnit tests}{}{}{}{https://github.com/kanonizo/kanonizo}
 
 \tlcventry{2015}{2018}{ReDeCheck: Automated detection of layout failures in responsive web pages}{}{}{}{https://github.com/redecheck/redecheck}
 
 \tlcventry{2012}{2021}{SchemaAnalyst: Search-based test data generation for relational database schemas}{}{}{}{https://github.com/schemaanalyst/schemaanalyst}
-
-\tlcventry{2018}{2021}{TaDA: Automated order-of-growth analysis for Python functions}{}{}{}{https://github.com/Tada-Project/tada}
 
 % PROFESSIONAL SERVICE
 %

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -504,11 +504,13 @@ the influence that technology has on society.}
 %
 \section{Software}
 
-\tlcventry{2016}{2021}{AVM{\em f}: Extensible framework for the search-based alternating variable method}{}{}{}{https://github.com/AVMf/avmf}
+\tlcventry{2016}{2020}{AVM{\em f}: Extensible framework for the search-based alternating variable method}{}{}{}{https://github.com/AVMf/avmf}
 
 \tlcventry{2019}{2021}{Dockagator: Docker image and infrastructure to run GatorGrader and GatorGradle}{}{}{}{https://github.com/GatorEducator/dockagator}
 
 \tlcventry{2017}{2021}{GatorGrader: Automated assessment for source code and technical writing}{}{}{}{https://github.com/GatorEducator/gatorgrader}
+
+\tlcventry{2018}{2021}{GatorGradle: Gradle plugin to support the use of GatorGrader}{}{}{}{https://github.com/GatorEducator/gatorgradle}
 
 \vspace*{-.1in}
 %

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -762,13 +762,21 @@ Engineering}{}{}{}{Session Chair (One time)}
 
 \tlcventry{2005}{2006}{Prentice Hall Books}{}{}{}{Reviewer (Two times)}
 
-\vspace*{-.1in}
-
+\vspace*{-.2in}
+%
 \section{Research Supervision}
 
 In addition to yearly senior thesis advising as part of CMPSC 600/601, I co-supervise graduate-level researchers.
 %
 \vspace*{.1in}
+
+\tlcventry{2016}{2020}{Abdullah Alsharif}{}{}{}{Doctor of Philosophy, University of Sheffield, Primary Supervision by Phil McMinn}
+
+\tlcventry{2015}{2019}{David Paterson}{}{}{}{Doctor of Philosophy, University of Sheffield, Primary Supervision by Phil McMinn}
+
+\tlcventry{2014}{2018}{Thomas Walsh}{}{}{}{Doctor of Philosophy, University of Sheffield, Primary Supervision by Phil McMinn}
+
+\tlcventry{2011}{2015}{Christopher Wright}{}{}{}{Doctor of Philosophy, University of Sheffield, Primary Supervision by Phil McMinn}
 
 \tlcventry{2009}{2011}{Akansha Aggarwal}{}{}{}{Master of Computer Science, Delhi University, Primary Supervision by Vidya Kulkarni}
 

--- a/curriculum_vitae_kapfhammer.tex
+++ b/curriculum_vitae_kapfhammer.tex
@@ -512,7 +512,15 @@ the influence that technology has on society.}
 
 \tlcventry{2018}{2021}{GatorGradle: Gradle plugin to support the use of GatorGrader}{}{}{}{https://github.com/GatorEducator/gatorgradle}
 
-\vspace*{-.1in}
+\tlcventry{2016}{2020}{Kanonizo: Improving fault detection with automated prioritization of JUnit tests}{}{}{}{https://github.com/kanonizo/kanonizo}
+
+\tlcventry{2015}{2018}{ReDeCheck: Automated detection of layout failures in responsive web pages}{}{}{}{https://github.com/redecheck/redecheck}
+
+\tlcventry{2012}{2021}{SchemaAnalyst: Search-based test data generation for relational database schemas}{}{}{}{https://github.com/schemaanalyst/schemaanalyst}
+
+\tlcventry{2018}{2021}{TaDA: Automated order-of-growth analysis for Python functions}{}{}{}{https://github.com/Tada-Project/tada}
+
+\vspace*{-.15in}
 %
 \section{Professional Service}
 


### PR DESCRIPTION
Add the supervision of graduate students, outreach, and software.

Summary of commits when PR was initially created:

- Update the documentation in the README.
- Add the first three software tools to curriculum_vitae_kapfhammer.
- Add the GatorGradle plugin to the curriculum_vitae_kapfhammer.
- Add three entries to software section in curriculum_vitae_kapfhammer.
- Remove phone number and add homepage in curriculum_vitae_kapfhammer.
- Add italics to journal names in curriculum_vitae_kapfhammer.
- Improve two comments in the curriculum_vitae_kapfhammer.
- Add comments to mark out sections of curriculum_vitae_kapfhammer.
- Add a comment and clarify "Service" in curriculum_vitae_kapfhammer.
- Update the bibliography Subproject.
- Add the start of research supervision in curriculum_vitae_kapfhammer.
- Add more supervision to curriculum_vitae_kapfhammer and move around.
- Add more Delhi University supervision in curriculum_vitae_kapfhammer.
- Delete not-needed comment in curriculum_vitae_kapfhammer.
- Tighten spacing above institutional service in curriculum_vitae_kapfhammer.
- Add supervision for Sheffield students in curriculum_vitae_kapfhammer.
- Add expected PhD students and fix spacing in curriculum_vitae_kapfhammer.
- Add two outreach activities in curriculum_vitae_kapfhammer.
- Reformat content in outreach in curriculum_vitae_kapfhammer.
